### PR TITLE
Use unique names when merging runtime deps

### DIFF
--- a/java_war/defs.bzl
+++ b/java_war/defs.bzl
@@ -26,7 +26,12 @@ def _collect_runtime_deps(deps):
 
 def _add_runtime_deps_args(zipper_args, runtime_deps):
     for runtime_dep in runtime_deps:
-        name = "WEB-INF/lib/" + runtime_dep.basename + "=" + runtime_dep.path
+        if runtime_dep.owner.package:
+            path_in_war = "%s/%s" % (runtime_dep.owner.package, runtime_dep.basename)
+        else:
+            path_in_war = runtime_dep.basename
+        path_in_war = path_in_war.replace("/", "_").replace("=", "_")
+        name = "WEB-INF/lib/" + path_in_war + "=" + runtime_dep.path
         zipper_args.append(name)
 
 def _war_impl(ctx):


### PR DESCRIPTION
If you have multiple targets with the same name in different packages, only one can exist in the war because only the basename is used.

For example, consider this `java_library`

```bzl
java_library(
    name = "serviceA",
    visibility = ["//visibility:public"],
    srcs = glob(["*.java"]),
    deps = [
        "//serviceA/src/main/java:utils",
        "//common/src/main/java:utils",
    ],
)
```

The resulting war file will only contain one `utils.jar` in the `WEB-INF/lib` directory, which would cause class not found errors at runtime.

I'm proposing including the package name to uniquely identify the project jars, similar to how `rules_appengine` [does it](https://github.com/bazelbuild/rules_appengine/blob/40ec3611f4108df23034281a743132770a40e820/appengine/java_appengine.bzl#L86-L89).